### PR TITLE
Change to new Buffer type

### DIFF
--- a/minestat.js
+++ b/minestat.js
@@ -39,7 +39,7 @@ module.exports =
 		const net = require('net');
 		const client = net.connect(port, address, () =>
 		{
-			var buff = new Buffer([ 0xFE, 0x01 ]);
+			var buff = Buffer.from([ 0xFE, 0x01 ]);
 			client.write(buff);
 		});
 


### PR DESCRIPTION
Found about this bot recently, and had to change one line to get it working.

Reference: https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues/52165509